### PR TITLE
feat: live TUI recording panel (#6)

### DIFF
--- a/spaceload/cli/main.py
+++ b/spaceload/cli/main.py
@@ -74,9 +74,19 @@ def cli() -> None:
     default=False,
     help="Also capture apps/tabs/projects already open when recording starts.",
 )
-def record(name: str, include_open: bool) -> None:
+@click.option(
+    "--no-tui",
+    is_flag=True,
+    default=False,
+    help="Disable the live TUI panel; print plain text instead (for CI/scripting).",
+)
+def record(name: str, include_open: bool, no_tui: bool) -> None:
     """Start recording a workspace session named NAME.
-    
+
+    By default, shows a live TUI panel with captured events in real time.
+    Use --no-tui to fall back to plain text output (useful in CI environments
+    or when stdout is not a terminal).
+
     By default, only captures new things opened during recording.
     Use --include-open to also capture everything already open.
     """
@@ -98,7 +108,7 @@ def record(name: str, include_open: bool) -> None:
         "--db",
         str(_DEFAULT_DB),
     ]
-    
+
     if include_open:
         daemon_cmd.append("--include-open")
 
@@ -109,7 +119,7 @@ def record(name: str, include_open: bool) -> None:
         start_new_session=True,  # detach from parent's process group
     )
 
-    # Give the daemon a moment to create the socket
+    # Wait for the daemon to create its socket (up to 2 s)
     import time
     for _ in range(20):
         if _SOCKET_PATH.exists():
@@ -122,11 +132,59 @@ def record(name: str, include_open: bool) -> None:
         )
         sys.exit(1)
 
-    msg = f"Recording started for '{name}'."
-    if include_open:
-        msg += " (including already open apps)"
-    msg += " Run 'spaceload stop' when done."
-    click.echo(msg)
+    # Decide whether to show the live TUI panel
+    use_tui = not no_tui and sys.stdout.isatty()
+
+    if use_tui:
+        _run_tui(name)
+    else:
+        # Plain-text fallback (original behaviour)
+        msg = f"Recording started for '{name}'."
+        if include_open:
+            msg += " (including already open apps)"
+        msg += " Run 'spaceload stop' when done."
+        click.echo(msg)
+
+
+def _run_tui(name: str) -> None:
+    """Run the foreground TUI loop, blocking until the user stops recording."""
+    import time
+
+    from spaceload.tui.event_poller import EventPoller
+    from spaceload.tui.recording_view import RecordingView
+    from spaceload.tui.renderer import Renderer
+    from spaceload.tui.summary_view import show_summary
+
+    poller = EventPoller(_SOCKET_PATH)
+    view = RecordingView(name)
+    renderer = Renderer()
+
+    try:
+        while True:
+            # Exit cleanly if the daemon was stopped externally
+            if not _daemon_is_running():
+                break
+            events = poller.poll()
+            view.update_events(events)
+            renderer.render(view)
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+
+    # Clear the live panel before printing the summary
+    renderer.clear()
+
+    # Stop the daemon if it is still running (Ctrl+C path)
+    action_count = view.total_events
+    if _daemon_is_running():
+        try:
+            response = _send_to_daemon({"command": "stop"})
+            if response.get("status") == "ok":
+                action_count = response.get("action_count", action_count)
+        except (ConnectionRefusedError, FileNotFoundError, OSError):
+            pass
+
+    show_summary(name, view, action_count)
 
 
 # ---------------------------------------------------------------------------

--- a/spaceload/daemon/server.py
+++ b/spaceload/daemon/server.py
@@ -1070,6 +1070,20 @@ class RecorderDaemon:
             }
             conn.sendall((json.dumps(response) + "\n").encode())
 
+        elif command == "events":
+            # Return all actions since the given offset index.
+            # Reading a slice of a list is safe under the GIL even though
+            # poller threads may concurrently append to self._actions.
+            since = int(msg.get("since", 0))
+            snapshot = self._actions[since:]
+            total = len(self._actions)
+            response = {
+                "status": "ok",
+                "events": snapshot,
+                "total": total,
+            }
+            conn.sendall((json.dumps(response) + "\n").encode())
+
         elif command == "record_action":
             action = msg.get("action", {})
             self._actions.append(action)

--- a/spaceload/tui/__init__.py
+++ b/spaceload/tui/__init__.py
@@ -1,0 +1,1 @@
+"""TUI module for spaceload — live recording panel and summary view."""

--- a/spaceload/tui/event_poller.py
+++ b/spaceload/tui/event_poller.py
@@ -1,0 +1,145 @@
+"""Polls the daemon socket for new recording events.
+
+The daemon accumulates actions in memory and exposes them via the
+``events`` socket command. EventPoller tracks the current offset so
+each call to poll() returns only new events since the last call.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class RecordingEvent:
+    adapter: str       # "browser", "ide", "terminal", "vpn", "app"
+    action: str        # "tab_opened", "project_captured", "session_opened", etc.
+    label: str         # human-readable description for display
+    timestamp: datetime
+    raw: dict = field(default_factory=dict, repr=False)
+
+
+def _raw_to_event(raw: dict) -> RecordingEvent:
+    """Convert a raw action dict to a RecordingEvent."""
+    t = raw.get("type", "")
+    try:
+        ts_str = raw.get("timestamp", "")
+        ts = datetime.fromisoformat(ts_str) if ts_str else datetime.now(timezone.utc)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        ts = datetime.now(timezone.utc)
+
+    if t == "browser_tab_open":
+        return RecordingEvent(
+            adapter="browser",
+            action="tab_opened",
+            label=raw.get("url", ""),
+            timestamp=ts,
+            raw=raw,
+        )
+    if t == "ide_project_open":
+        return RecordingEvent(
+            adapter="ide",
+            action="project_captured",
+            label=raw.get("path", ""),
+            timestamp=ts,
+            raw=raw,
+        )
+    if t == "terminal_session_open":
+        return RecordingEvent(
+            adapter="terminal",
+            action="session_opened",
+            label=raw.get("directory", ""),
+            timestamp=ts,
+            raw=raw,
+        )
+    if t == "vpn_connect":
+        client = raw.get("client", "vpn")
+        profile = raw.get("profile")
+        label = f"{client} ({profile})" if profile else client
+        return RecordingEvent(
+            adapter="vpn",
+            action="connected",
+            label=label,
+            timestamp=ts,
+            raw=raw,
+        )
+    if t == "vpn_disconnect":
+        return RecordingEvent(
+            adapter="vpn",
+            action="disconnected",
+            label=raw.get("client", "vpn"),
+            timestamp=ts,
+            raw=raw,
+        )
+    if t == "app_open":
+        return RecordingEvent(
+            adapter="app",
+            action="opened",
+            label=raw.get("app_name", ""),
+            timestamp=ts,
+            raw=raw,
+        )
+    return RecordingEvent(
+        adapter="unknown",
+        action=t,
+        label=raw.get("app_name", raw.get("url", raw.get("path", str(raw)))),
+        timestamp=ts,
+        raw=raw,
+    )
+
+
+class EventPoller:
+    """Polls the daemon Unix socket for new recording events.
+
+    Tracks an offset into the daemon's action list and fetches only
+    actions that arrived since the previous successful poll.
+
+    Returns an empty list — rather than raising — when the daemon is
+    unreachable, so the TUI can keep rendering without crashing.
+    """
+
+    def __init__(self, socket_path: Path, poll_interval: float = 0.5) -> None:
+        self._socket_path = socket_path
+        self.poll_interval = poll_interval
+        self._offset: int = 0
+
+    def poll(self) -> list[RecordingEvent]:
+        """Return new events since the last successful poll."""
+        try:
+            payload = (json.dumps({"command": "events", "since": self._offset}) + "\n").encode()
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                sock.settimeout(1.0)
+                sock.connect(str(self._socket_path))
+                sock.sendall(payload)
+                data = b""
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+                    if b"\n" in data:
+                        break
+            finally:
+                sock.close()
+
+            response = json.loads(data.decode().strip())
+            if response.get("status") != "ok":
+                return []
+
+            new_events = response.get("events", [])
+            self._offset = response.get("total", self._offset)
+            return [_raw_to_event(e) for e in new_events]
+
+        except Exception:
+            return []
+
+    def reset(self) -> None:
+        """Reset the polling offset back to zero."""
+        self._offset = 0

--- a/spaceload/tui/recording_view.py
+++ b/spaceload/tui/recording_view.py
@@ -1,0 +1,138 @@
+"""Live recording state — accumulates events and tracks elapsed time.
+
+RecordingView is a pure data container: it holds everything the renderer
+needs to draw the panel. Call update_events() each poll cycle to ingest
+new events from the EventPoller.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import NamedTuple
+
+from spaceload.tui.event_poller import RecordingEvent
+
+
+class BrowserEntry(NamedTuple):
+    url: str
+    timestamp: datetime
+
+
+class IDEEntry(NamedTuple):
+    path: str
+    client: str
+    timestamp: datetime
+
+
+class TerminalEntry(NamedTuple):
+    directory: str
+    app: str
+    timestamp: datetime
+
+
+class RecordingView:
+    """Mutable state snapshot for the live recording TUI panel.
+
+    All mutation goes through update_events(); all reads are via
+    properties so the renderer never writes state accidentally.
+    """
+
+    def __init__(self, workspace_name: str) -> None:
+        self.workspace_name = workspace_name
+        self.start_time: datetime = datetime.now(timezone.utc)
+
+        self._browser_tabs: dict[str, list[BrowserEntry]] = {}
+        self._ide_projects: dict[str, list[IDEEntry]] = {}
+        self._terminal_sessions: dict[str, list[TerminalEntry]] = {}
+        self._vpn_connected: bool = False
+        self._vpn_label: str = "not connected"
+        self._total_events: int = 0
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def update_events(self, events: list[RecordingEvent]) -> None:
+        """Ingest a batch of new events from the EventPoller."""
+        for event in events:
+            self._total_events += 1
+            adapter = event.adapter
+
+            if adapter == "browser":
+                browser = event.raw.get("browser", "browser")
+                self._browser_tabs.setdefault(browser, []).append(
+                    BrowserEntry(url=event.label, timestamp=event.timestamp)
+                )
+
+            elif adapter == "ide":
+                client = event.raw.get("client", "IDE")
+                self._ide_projects.setdefault(client, []).append(
+                    IDEEntry(path=event.label, client=client, timestamp=event.timestamp)
+                )
+
+            elif adapter == "terminal":
+                app = event.raw.get("app", "terminal")
+                self._terminal_sessions.setdefault(app, []).append(
+                    TerminalEntry(
+                        directory=event.label, app=app, timestamp=event.timestamp
+                    )
+                )
+
+            elif adapter == "vpn":
+                if event.action == "connected":
+                    self._vpn_connected = True
+                    self._vpn_label = event.label
+                elif event.action == "disconnected":
+                    self._vpn_connected = False
+                    self._vpn_label = "not connected"
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    def elapsed(self) -> float:
+        """Seconds elapsed since recording started."""
+        return (datetime.now(timezone.utc) - self.start_time).total_seconds()
+
+    def elapsed_str(self) -> str:
+        """Elapsed time as HH:MM:SS."""
+        secs = int(self.elapsed())
+        h, rem = divmod(secs, 3600)
+        m, s = divmod(rem, 60)
+        return f"{h:02d}:{m:02d}:{s:02d}"
+
+    @property
+    def browser_tabs(self) -> dict[str, list[BrowserEntry]]:
+        return self._browser_tabs
+
+    @property
+    def ide_projects(self) -> dict[str, list[IDEEntry]]:
+        return self._ide_projects
+
+    @property
+    def terminal_sessions(self) -> dict[str, list[TerminalEntry]]:
+        return self._terminal_sessions
+
+    @property
+    def vpn_connected(self) -> bool:
+        return self._vpn_connected
+
+    @property
+    def vpn_label(self) -> str:
+        return self._vpn_label
+
+    @property
+    def total_events(self) -> int:
+        return self._total_events
+
+    def summary_counts(self) -> dict:
+        """Aggregated counts for the final summary display."""
+        return {
+            "browser": {b: len(tabs) for b, tabs in self._browser_tabs.items()},
+            "ide": {c: len(projs) for c, projs in self._ide_projects.items()},
+            "terminal_count": sum(
+                len(sessions) for sessions in self._terminal_sessions.values()
+            ),
+            "terminal_app": next(iter(self._terminal_sessions), None),
+            "vpn": self._vpn_label if self._vpn_connected else "not connected",
+        }

--- a/spaceload/tui/renderer.py
+++ b/spaceload/tui/renderer.py
@@ -1,0 +1,275 @@
+"""ANSI terminal renderer for the live recording panel.
+
+Uses only raw ANSI escape codes — no external dependencies required.
+Gracefully degrades to a no-op when stdout is not a TTY (CI, pipes).
+
+Panel anatomy (W = total width, C = W - 6 = usable content chars):
+
+    ╭─ spaceload recording ─────────────────────────────────╮  <- W chars
+    │  {content}{padding}  │                                   <- W chars
+    ╰───────────────────────────────────────────────────────╯  <- W chars
+
+The renderer tracks how many lines it printed last cycle and moves the
+cursor back up to overwrite them on the next call to render().
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spaceload.tui.recording_view import RecordingView
+
+# ---------------------------------------------------------------------------
+# ANSI color codes
+# ---------------------------------------------------------------------------
+
+_RESET = "\033[0m"
+_GREEN = "\033[32m"
+_BRIGHT_GREEN = "\033[92m"
+_DIM = "\033[2m"
+_BOLD = "\033[1m"
+_CYAN = "\033[36m"
+
+# Strip ANSI codes to compute visual (on-screen) length
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+
+def _vlen(s: str) -> int:
+    """Visual length of *s* after stripping ANSI escape codes."""
+    return len(_ANSI_RE.sub("", s))
+
+
+# ---------------------------------------------------------------------------
+# Box-drawing characters
+# ---------------------------------------------------------------------------
+
+_TL = "╭"
+_TR = "╮"
+_BL = "╰"
+_BR = "╯"
+_H = "─"
+_V = "│"
+_ML = "├"
+_MR = "┤"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def is_tty() -> bool:
+    """Return True when stdout is an interactive terminal."""
+    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _panel_width() -> int:
+    """Total panel width in characters (including the two border chars)."""
+    cols = shutil.get_terminal_size((80, 24)).columns
+    return min(max(cols, 62), 102)
+
+
+def _rel_time(ts: datetime) -> str:
+    """Human-readable relative timestamp (e.g. 'just now', '1:23 ago')."""
+    secs = int((datetime.now(timezone.utc) - ts).total_seconds())
+    if secs < 5:
+        return "just now"
+    if secs < 60:
+        return f"{secs}s ago"
+    m, s = divmod(secs, 60)
+    if m < 60:
+        return f"{m}:{s:02d} ago"
+    return "long ago"
+
+
+def _trunc(text: str, n: int) -> str:
+    """Truncate *text* to *n* chars, appending '…' when cut."""
+    if len(text) <= n:
+        return text
+    return text[: n - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+class Renderer:
+    """Renders the live recording panel to an ANSI terminal.
+
+    Call render(view) in a loop; call clear() before printing anything
+    else (e.g. the final summary).
+    """
+
+    def __init__(self) -> None:
+        self._last_lines: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def render(self, view: "RecordingView") -> None:
+        """Redraw the live panel in place.
+
+        First call: prints the panel fresh.
+        Subsequent calls: moves cursor up and overwrites the previous frame.
+        Falls back to a no-op when stdout is not a TTY.
+        """
+        if not is_tty():
+            return
+
+        lines = self._build(view)
+
+        if self._last_lines > 0:
+            # Move cursor back to the top of the previous frame
+            sys.stdout.write(f"\033[{self._last_lines}A")
+
+        for line in lines:
+            # \033[K clears from cursor to end of line (handles shrinking panels)
+            sys.stdout.write(line + "\033[K\n")
+
+        sys.stdout.flush()
+        self._last_lines = len(lines)
+
+    def clear(self) -> None:
+        """Erase the last rendered panel from the terminal."""
+        if not is_tty() or self._last_lines == 0:
+            return
+        sys.stdout.write(f"\033[{self._last_lines}A\033[J")
+        sys.stdout.flush()
+        self._last_lines = 0
+
+    # ------------------------------------------------------------------
+    # Panel layout
+    # ------------------------------------------------------------------
+
+    def _row(self, colored: str, W: int) -> str:
+        """Build a single panel row with correct border and padding.
+
+        colored  — content string (may contain ANSI codes)
+        W        — total panel width (including the two │ chars)
+        """
+        C = W - 6  # usable content: W - 2 borders - 2 left pad - 2 right pad
+        pad = max(0, C - _vlen(colored))
+        return f"{_V}  {colored}{' ' * pad}  {_V}"
+
+    def _blank(self, W: int) -> str:
+        """An empty panel row (used as section separator)."""
+        return f"{_V}{' ' * (W - 2)}{_V}"
+
+    def _build(self, view: "RecordingView") -> list[str]:
+        """Build and return the full list of terminal lines for one frame."""
+        W = _panel_width()
+        H = W - 2   # fill width for horizontal borders (between corner chars)
+        C = W - 6   # usable content width
+
+        lines: list[str] = []
+
+        # ── Top border ────────────────────────────────────────────────
+        title_v = " spaceload recording "
+        title_c = f"{_BOLD}{_CYAN}{title_v}{_RESET}"
+        right_dashes = _H * (H - len(title_v) - 1)
+        lines.append(f"{_TL}{_H}{title_c}{right_dashes}{_TR}")
+
+        # ── Workspace + elapsed time ───────────────────────────────────
+        ws_v = f"Workspace: {view.workspace_name}"
+        elapsed = view.elapsed_str()
+        inner_pad = max(0, C - len(ws_v) - len(elapsed))
+        ws_c = f"Workspace: {_BOLD}{view.workspace_name}{_RESET}"
+        elapsed_c = f"{_DIM}{elapsed}{_RESET}"
+        lines.append(f"{_V}  {ws_c}{' ' * inner_pad}{elapsed_c}  {_V}")
+
+        # ── Recording indicator ────────────────────────────────────────
+        dot = f"{_BRIGHT_GREEN}●{_RESET}"
+        rec_c = f"Status: {dot} {_GREEN}RECORDING{_RESET}"
+        lines.append(self._row(rec_c, W))
+
+        # ── Separator ─────────────────────────────────────────────────
+        lines.append(f"{_ML}{_H * H}{_MR}")
+
+        # ── Browser section ───────────────────────────────────────────
+        browser_tabs = view.browser_tabs
+        if browser_tabs:
+            for browser, tabs in browser_tabs.items():
+                hdr = f"{_BOLD}Browser{_RESET}           {_CYAN}{browser}{_RESET}"
+                lines.append(self._row(hdr, W))
+                for i, tab in enumerate(tabs):
+                    tree = "└─" if i == len(tabs) - 1 else "├─"
+                    rel = _rel_time(tab.timestamp)
+                    # tree(2) + space(1) = 3 prefix; trailing rel + 1 space = len(rel)+1
+                    url_max = C - 3 - len(rel) - 1
+                    url = _trunc(tab.url, max(url_max, 10))
+                    gap = max(1, C - 3 - len(url) - len(rel))
+                    row_c = (
+                        f"{_DIM}{tree}{_RESET} {_GREEN}{url}{_RESET}"
+                        f"{' ' * gap}{_DIM}{rel}{_RESET}"
+                    )
+                    lines.append(self._row(row_c, W))
+        else:
+            hdr = f"{_BOLD}Browser{_RESET}           {_DIM}not captured yet{_RESET}"
+            lines.append(self._row(hdr, W))
+
+        lines.append(self._blank(W))
+
+        # ── IDE section ───────────────────────────────────────────────
+        ide_projects = view.ide_projects
+        if ide_projects:
+            for client, projects in ide_projects.items():
+                hdr = f"{_BOLD}IDE{_RESET}               {_CYAN}{client}{_RESET}"
+                lines.append(self._row(hdr, W))
+                for i, proj in enumerate(projects):
+                    tree = "└─" if i == len(projects) - 1 else "├─"
+                    label = "captured"
+                    path_max = C - 3 - len(label) - 1
+                    path = _trunc(proj.path, max(path_max, 10))
+                    gap = max(1, C - 3 - len(path) - len(label))
+                    row_c = (
+                        f"{_DIM}{tree}{_RESET} {path}"
+                        f"{' ' * gap}{_GREEN}{label}{_RESET}"
+                    )
+                    lines.append(self._row(row_c, W))
+        else:
+            hdr = f"{_BOLD}IDE{_RESET}               {_DIM}not captured yet{_RESET}"
+            lines.append(self._row(hdr, W))
+
+        lines.append(self._blank(W))
+
+        # ── Terminal section ──────────────────────────────────────────
+        terminal_sessions = view.terminal_sessions
+        if terminal_sessions:
+            for app, sessions in terminal_sessions.items():
+                count = len(sessions)
+                plural = "s" if count != 1 else ""
+                app_label = f"{app} ({count} session{plural})"
+                hdr = f"{_BOLD}Terminal{_RESET}          {_CYAN}{app_label}{_RESET}"
+                lines.append(self._row(hdr, W))
+                for i, sess in enumerate(sessions):
+                    tree = "└─" if i == len(sessions) - 1 else "├─"
+                    d = _trunc(sess.directory, C - 3)
+                    gap = max(0, C - 3 - len(d))
+                    row_c = f"{_DIM}{tree}{_RESET} {d}{' ' * gap}"
+                    lines.append(self._row(row_c, W))
+        else:
+            hdr = f"{_BOLD}Terminal{_RESET}          {_DIM}not captured yet{_RESET}"
+            lines.append(self._row(hdr, W))
+
+        lines.append(self._blank(W))
+
+        # ── VPN section ───────────────────────────────────────────────
+        vpn_color = _GREEN if view.vpn_connected else _DIM
+        vpn_c = f"{_BOLD}VPN{_RESET}               {vpn_color}{view.vpn_label}{_RESET}"
+        lines.append(self._row(vpn_c, W))
+
+        # ── Bottom border ─────────────────────────────────────────────
+        lines.append(f"{_BL}{_H * H}{_BR}")
+
+        # ── Footer hint ───────────────────────────────────────────────
+        lines.append(
+            f"  {_DIM}Press Ctrl+C or run `spaceload stop` to finish recording{_RESET}"
+        )
+
+        return lines

--- a/spaceload/tui/summary_view.py
+++ b/spaceload/tui/summary_view.py
@@ -1,0 +1,56 @@
+"""Final static summary displayed after a recording session ends."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from spaceload.tui.recording_view import RecordingView
+
+
+def show_summary(workspace_name: str, view: "RecordingView", action_count: int) -> None:
+    """Print a clean static summary of what was captured.
+
+    This is intentionally plain text (no ANSI) so it remains readable
+    when redirected to a file or when the terminal is scrolled back.
+    """
+    elapsed = view.elapsed_str()
+    counts = view.summary_counts()
+
+    out = sys.stdout.write
+
+    out(f"\nRecording complete: {workspace_name}\n")
+    out(f"Duration: {elapsed}\n")
+    out("\nCaptured:\n")
+
+    # Browser
+    if counts["browser"]:
+        for browser, count in counts["browser"].items():
+            plural = "s" if count != 1 else ""
+            out(f"  Browser tab{plural}:  {count} ({browser})\n")
+    else:
+        out("  Browser tabs:  none\n")
+
+    # IDE
+    if counts["ide"]:
+        for client, count in counts["ide"].items():
+            plural = "s" if count != 1 else ""
+            out(f"  IDE:           {client} \u2014 {count} project{plural}\n")
+    else:
+        out("  IDE:           none\n")
+
+    # Terminal
+    tc = counts["terminal_count"]
+    if tc:
+        app = counts["terminal_app"] or "terminal"
+        plural = "s" if tc != 1 else ""
+        out(f"  Terminal{plural}:      {tc} session{plural} ({app})\n")
+    else:
+        out("  Terminals:     none\n")
+
+    # VPN
+    out(f"  VPN:           {counts['vpn']}\n")
+
+    out(f"\nSaved {action_count} actions. Run it with: spaceload run {workspace_name}\n\n")
+    sys.stdout.flush()

--- a/tests/tui/test_event_poller.py
+++ b/tests/tui/test_event_poller.py
@@ -1,0 +1,241 @@
+"""Tests for spaceload.tui.event_poller."""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from spaceload.tui.event_poller import EventPoller, RecordingEvent, _raw_to_event
+
+
+# ---------------------------------------------------------------------------
+# _raw_to_event conversion
+# ---------------------------------------------------------------------------
+
+class TestRawToEvent:
+    def test_browser_tab_open(self):
+        raw = {
+            "type": "browser_tab_open",
+            "browser": "arc",
+            "url": "https://example.com",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "browser"
+        assert evt.action == "tab_opened"
+        assert evt.label == "https://example.com"
+        assert evt.raw["browser"] == "arc"
+
+    def test_ide_project_open(self):
+        raw = {
+            "type": "ide_project_open",
+            "client": "vscode",
+            "path": "/Users/tom/code/myapp",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "ide"
+        assert evt.action == "project_captured"
+        assert evt.label == "/Users/tom/code/myapp"
+
+    def test_terminal_session_open(self):
+        raw = {
+            "type": "terminal_session_open",
+            "app": "iterm2",
+            "directory": "/Users/tom/code",
+            "session_id": "s1",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "terminal"
+        assert evt.action == "session_opened"
+        assert evt.label == "/Users/tom/code"
+
+    def test_vpn_connect_with_profile(self):
+        raw = {
+            "type": "vpn_connect",
+            "client": "tailscale",
+            "profile": "work",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "vpn"
+        assert evt.action == "connected"
+        assert "tailscale" in evt.label
+        assert "work" in evt.label
+
+    def test_vpn_connect_without_profile(self):
+        raw = {
+            "type": "vpn_connect",
+            "client": "tailscale",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.label == "tailscale"
+
+    def test_vpn_disconnect(self):
+        raw = {
+            "type": "vpn_disconnect",
+            "client": "tailscale",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "vpn"
+        assert evt.action == "disconnected"
+
+    def test_app_open(self):
+        raw = {
+            "type": "app_open",
+            "app_name": "Figma",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "app"
+        assert evt.label == "Figma"
+
+    def test_unknown_type(self):
+        raw = {"type": "future_type", "timestamp": "2024-01-01T10:00:00+00:00"}
+        evt = _raw_to_event(raw)
+        assert evt.adapter == "unknown"
+        assert evt.action == "future_type"
+
+    def test_missing_timestamp_defaults_to_now(self):
+        raw = {"type": "browser_tab_open", "url": "https://x.com"}
+        before = datetime.now(timezone.utc)
+        evt = _raw_to_event(raw)
+        after = datetime.now(timezone.utc)
+        assert before <= evt.timestamp <= after
+
+    def test_timestamp_gets_utc_tzinfo(self):
+        raw = {
+            "type": "browser_tab_open",
+            "url": "https://x.com",
+            "timestamp": "2024-01-01T10:00:00",  # naive ISO
+        }
+        evt = _raw_to_event(raw)
+        assert evt.timestamp.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# EventPoller — daemon not running
+# ---------------------------------------------------------------------------
+
+class TestEventPollerNoDaemon:
+    def test_returns_empty_list_when_socket_missing(self, tmp_path):
+        poller = EventPoller(tmp_path / "missing.sock")
+        result = poller.poll()
+        assert result == []
+
+    def test_does_not_raise_on_connection_error(self, tmp_path):
+        poller = EventPoller(tmp_path / "missing.sock")
+        # Should not raise
+        for _ in range(3):
+            poller.poll()
+
+    def test_offset_stays_zero_on_failure(self, tmp_path):
+        poller = EventPoller(tmp_path / "missing.sock")
+        poller.poll()
+        assert poller._offset == 0
+
+
+# ---------------------------------------------------------------------------
+# EventPoller — with a mock daemon socket
+# ---------------------------------------------------------------------------
+
+def _short_sock_path(name: str) -> Path:
+    """Return a short Unix socket path (macOS limit is 104 chars)."""
+    import tempfile
+    return Path(tempfile.mkdtemp()) / f"{name}.sock"
+
+
+def _start_mock_daemon(sock_path: Path, responses: list[dict]) -> threading.Thread:
+    """Start a Unix socket server that serves canned responses."""
+    response_iter = iter(responses)
+
+    def _serve():
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(5)
+        server.settimeout(2.0)
+        try:
+            for _ in range(len(responses)):
+                try:
+                    conn, _ = server.accept()
+                    conn.recv(4096)  # consume the request
+                    reply = json.dumps(next(response_iter)) + "\n"
+                    conn.sendall(reply.encode())
+                    conn.close()
+                except socket.timeout:
+                    break
+        finally:
+            server.close()
+
+    t = threading.Thread(target=_serve, daemon=True)
+    t.start()
+    return t
+
+
+class TestEventPollerWithMockDaemon:
+    def test_returns_events_from_daemon(self):
+        sock_path = _short_sock_path("ev1")
+        event_raw = {
+            "type": "browser_tab_open",
+            "browser": "arc",
+            "url": "https://example.com",
+            "timestamp": "2024-01-01T10:00:00+00:00",
+        }
+        response = {"status": "ok", "events": [event_raw], "total": 1}
+        _start_mock_daemon(sock_path, [response])
+
+        import time
+        time.sleep(0.05)  # let server start
+
+        poller = EventPoller(sock_path)
+        events = poller.poll()
+
+        assert len(events) == 1
+        assert isinstance(events[0], RecordingEvent)
+        assert events[0].adapter == "browser"
+        assert events[0].label == "https://example.com"
+
+    def test_tracks_offset_correctly(self):
+        sock_path = _short_sock_path("ev2")
+        responses = [
+            {"status": "ok", "events": [{"type": "browser_tab_open", "url": "https://a.com", "timestamp": "2024-01-01T10:00:00+00:00"}], "total": 1},
+            {"status": "ok", "events": [{"type": "browser_tab_open", "url": "https://b.com", "timestamp": "2024-01-01T10:00:00+00:00"}], "total": 2},
+        ]
+        _start_mock_daemon(sock_path, responses)
+
+        import time
+        time.sleep(0.05)
+
+        poller = EventPoller(sock_path)
+        first = poller.poll()
+        assert poller._offset == 1
+        second = poller.poll()
+        assert poller._offset == 2
+        assert len(first) == 1
+        assert len(second) == 1
+
+    def test_empty_events_on_error_status(self):
+        sock_path = _short_sock_path("ev3")
+        _start_mock_daemon(sock_path, [{"status": "error", "reason": "test"}])
+
+        import time
+        time.sleep(0.05)
+
+        poller = EventPoller(sock_path)
+        events = poller.poll()
+        assert events == []
+
+    def test_reset_clears_offset(self, tmp_path):
+        poller = EventPoller(tmp_path / "daemon.sock")
+        poller._offset = 42
+        poller.reset()
+        assert poller._offset == 0

--- a/tests/tui/test_recording_view.py
+++ b/tests/tui/test_recording_view.py
@@ -1,0 +1,216 @@
+"""Tests for spaceload.tui.recording_view."""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from spaceload.tui.event_poller import RecordingEvent
+from spaceload.tui.recording_view import RecordingView
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _make_event(adapter: str, action: str, label: str, raw: dict | None = None) -> RecordingEvent:
+    return RecordingEvent(
+        adapter=adapter,
+        action=action,
+        label=label,
+        timestamp=_now(),
+        raw=raw or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+class TestRecordingViewInit:
+    def test_starts_empty(self):
+        view = RecordingView("my-project")
+        assert view.workspace_name == "my-project"
+        assert view.browser_tabs == {}
+        assert view.ide_projects == {}
+        assert view.terminal_sessions == {}
+        assert not view.vpn_connected
+        assert view.vpn_label == "not connected"
+        assert view.total_events == 0
+
+    def test_start_time_is_recent(self):
+        before = datetime.now(timezone.utc)
+        view = RecordingView("test")
+        after = datetime.now(timezone.utc)
+        assert before <= view.start_time <= after
+
+
+# ---------------------------------------------------------------------------
+# update_events — browser
+# ---------------------------------------------------------------------------
+
+class TestBrowserEvents:
+    def test_adds_browser_tab(self):
+        view = RecordingView("p")
+        evt = _make_event(
+            "browser", "tab_opened", "https://example.com",
+            raw={"browser": "arc", "url": "https://example.com"},
+        )
+        view.update_events([evt])
+        assert "arc" in view.browser_tabs
+        assert len(view.browser_tabs["arc"]) == 1
+        assert view.browser_tabs["arc"][0].url == "https://example.com"
+
+    def test_groups_by_browser(self):
+        view = RecordingView("p")
+        view.update_events([
+            _make_event("browser", "tab_opened", "https://a.com", raw={"browser": "arc", "url": "https://a.com"}),
+            _make_event("browser", "tab_opened", "https://b.com", raw={"browser": "chrome", "url": "https://b.com"}),
+        ])
+        assert "arc" in view.browser_tabs
+        assert "chrome" in view.browser_tabs
+
+    def test_multiple_tabs_same_browser(self):
+        view = RecordingView("p")
+        for url in ["https://a.com", "https://b.com", "https://c.com"]:
+            view.update_events([
+                _make_event("browser", "tab_opened", url, raw={"browser": "arc", "url": url})
+            ])
+        assert len(view.browser_tabs["arc"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# update_events — IDE
+# ---------------------------------------------------------------------------
+
+class TestIDEEvents:
+    def test_adds_ide_project(self):
+        view = RecordingView("p")
+        evt = _make_event(
+            "ide", "project_captured", "/Users/tom/myapp",
+            raw={"client": "vscode", "path": "/Users/tom/myapp"},
+        )
+        view.update_events([evt])
+        assert "vscode" in view.ide_projects
+        assert view.ide_projects["vscode"][0].path == "/Users/tom/myapp"
+
+    def test_groups_by_client(self):
+        view = RecordingView("p")
+        view.update_events([
+            _make_event("ide", "project_captured", "/a", raw={"client": "vscode", "path": "/a"}),
+            _make_event("ide", "project_captured", "/b", raw={"client": "cursor", "path": "/b"}),
+        ])
+        assert "vscode" in view.ide_projects
+        assert "cursor" in view.ide_projects
+
+
+# ---------------------------------------------------------------------------
+# update_events — terminal
+# ---------------------------------------------------------------------------
+
+class TestTerminalEvents:
+    def test_adds_terminal_session(self):
+        view = RecordingView("p")
+        evt = _make_event(
+            "terminal", "session_opened", "/Users/tom/code",
+            raw={"app": "iterm2", "directory": "/Users/tom/code"},
+        )
+        view.update_events([evt])
+        assert "iterm2" in view.terminal_sessions
+        assert view.terminal_sessions["iterm2"][0].directory == "/Users/tom/code"
+
+    def test_multiple_sessions_same_app(self):
+        view = RecordingView("p")
+        for d in ["/a", "/b"]:
+            view.update_events([
+                _make_event("terminal", "session_opened", d, raw={"app": "iterm2", "directory": d})
+            ])
+        assert len(view.terminal_sessions["iterm2"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# update_events — VPN
+# ---------------------------------------------------------------------------
+
+class TestVPNEvents:
+    def test_vpn_connect(self):
+        view = RecordingView("p")
+        evt = _make_event("vpn", "connected", "tailscale (work)")
+        view.update_events([evt])
+        assert view.vpn_connected
+        assert view.vpn_label == "tailscale (work)"
+
+    def test_vpn_disconnect(self):
+        view = RecordingView("p")
+        view.update_events([_make_event("vpn", "connected", "tailscale")])
+        view.update_events([_make_event("vpn", "disconnected", "tailscale")])
+        assert not view.vpn_connected
+        assert view.vpn_label == "not connected"
+
+    def test_unknown_adapter_increments_count(self):
+        view = RecordingView("p")
+        evt = _make_event("app", "opened", "Figma")
+        view.update_events([evt])
+        assert view.total_events == 1
+
+
+# ---------------------------------------------------------------------------
+# Elapsed time
+# ---------------------------------------------------------------------------
+
+class TestElapsedTime:
+    def test_elapsed_str_format(self):
+        view = RecordingView("p")
+        elapsed = view.elapsed_str()
+        parts = elapsed.split(":")
+        assert len(parts) == 3
+        assert all(part.isdigit() for part in parts)
+
+    def test_elapsed_increases_over_time(self):
+        view = RecordingView("p")
+        t1 = view.elapsed()
+        time.sleep(0.05)
+        t2 = view.elapsed()
+        assert t2 > t1
+
+    def test_elapsed_str_zero_padded(self):
+        view = RecordingView("p")
+        s = view.elapsed_str()
+        h, m, sec = s.split(":")
+        assert len(h) == 2
+        assert len(m) == 2
+        assert len(sec) == 2
+
+
+# ---------------------------------------------------------------------------
+# summary_counts
+# ---------------------------------------------------------------------------
+
+class TestSummaryCounts:
+    def test_empty_view(self):
+        view = RecordingView("p")
+        counts = view.summary_counts()
+        assert counts["browser"] == {}
+        assert counts["ide"] == {}
+        assert counts["terminal_count"] == 0
+        assert counts["terminal_app"] is None
+        assert counts["vpn"] == "not connected"
+
+    def test_with_events(self):
+        view = RecordingView("p")
+        view.update_events([
+            _make_event("browser", "tab_opened", "https://a.com", raw={"browser": "arc", "url": "https://a.com"}),
+            _make_event("browser", "tab_opened", "https://b.com", raw={"browser": "arc", "url": "https://b.com"}),
+            _make_event("ide", "project_captured", "/x", raw={"client": "vscode", "path": "/x"}),
+            _make_event("terminal", "session_opened", "/y", raw={"app": "iterm2", "directory": "/y"}),
+            _make_event("terminal", "session_opened", "/z", raw={"app": "iterm2", "directory": "/z"}),
+            _make_event("vpn", "connected", "tailscale"),
+        ])
+        counts = view.summary_counts()
+        assert counts["browser"]["arc"] == 2
+        assert counts["ide"]["vscode"] == 1
+        assert counts["terminal_count"] == 2
+        assert counts["terminal_app"] == "iterm2"
+        assert counts["vpn"] == "tailscale"

--- a/tests/tui/test_renderer.py
+++ b/tests/tui/test_renderer.py
@@ -1,0 +1,239 @@
+"""Tests for spaceload.tui.renderer."""
+
+from __future__ import annotations
+
+import io
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from spaceload.tui.event_poller import RecordingEvent
+from spaceload.tui.recording_view import RecordingView
+from spaceload.tui.renderer import Renderer, _rel_time, _trunc, _vlen, is_tty
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_vlen_strips_ansi(self):
+        colored = "\033[32mhello\033[0m"
+        assert _vlen(colored) == 5
+
+    def test_vlen_plain_string(self):
+        assert _vlen("hello world") == 11
+
+    def test_vlen_nested_codes(self):
+        s = "\033[1m\033[32mfoo\033[0m"
+        assert _vlen(s) == 3
+
+    def test_trunc_short_string(self):
+        assert _trunc("hello", 10) == "hello"
+
+    def test_trunc_exact_length(self):
+        assert _trunc("hello", 5) == "hello"
+
+    def test_trunc_truncates(self):
+        result = _trunc("hello world", 8)
+        assert len(result) == 8
+        assert result.endswith("…")
+
+    def test_rel_time_just_now(self):
+        ts = datetime.now(timezone.utc)
+        assert _rel_time(ts) == "just now"
+
+    def test_rel_time_seconds(self):
+        ts = datetime.now(timezone.utc) - timedelta(seconds=30)
+        result = _rel_time(ts)
+        assert "s ago" in result
+
+    def test_rel_time_minutes(self):
+        ts = datetime.now(timezone.utc) - timedelta(minutes=2, seconds=5)
+        result = _rel_time(ts)
+        assert "ago" in result
+        assert ":" in result
+
+
+# ---------------------------------------------------------------------------
+# is_tty
+# ---------------------------------------------------------------------------
+
+class TestIsTTY:
+    def test_returns_false_in_test_env(self):
+        # In pytest, stdout is captured (not a TTY)
+        assert not is_tty()
+
+    def test_returns_false_for_string_io(self):
+        with patch("sys.stdout", new=io.StringIO()):
+            assert not is_tty()
+
+
+# ---------------------------------------------------------------------------
+# Renderer — non-TTY (no-op)
+# ---------------------------------------------------------------------------
+
+class TestRendererNonTTY:
+    def test_render_is_noop_when_not_tty(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        captured = io.StringIO()
+        with patch("sys.stdout", new=captured):
+            renderer.render(view)
+        assert captured.getvalue() == ""
+
+    def test_clear_is_noop_when_not_tty(self):
+        renderer = Renderer()
+        captured = io.StringIO()
+        with patch("sys.stdout", new=captured):
+            renderer.clear()
+        assert captured.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Renderer — panel construction (tested via _build, bypasses TTY check)
+# ---------------------------------------------------------------------------
+
+def _make_view_with_events() -> RecordingView:
+    view = RecordingView("my-project")
+    ts = datetime.now(timezone.utc)
+    view.update_events([
+        RecordingEvent("browser", "tab_opened", "https://localhost:3000", ts,
+                       raw={"browser": "Arc", "url": "https://localhost:3000"}),
+        RecordingEvent("ide", "project_captured", "/Users/tom/code/myapp", ts,
+                       raw={"client": "VS Code", "path": "/Users/tom/code/myapp"}),
+        RecordingEvent("terminal", "session_opened", "/Users/tom/code", ts,
+                       raw={"app": "iTerm2", "directory": "/Users/tom/code"}),
+        RecordingEvent("vpn", "connected", "tailscale (work)", ts, raw={}),
+    ])
+    return view
+
+
+class TestRendererBuild:
+    def test_panel_contains_workspace_name(self):
+        renderer = Renderer()
+        view = RecordingView("my-project")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "my-project" in panel
+
+    def test_panel_contains_elapsed_time(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        # elapsed time always starts with "00:"
+        assert "00:" in panel
+
+    def test_panel_contains_recording_indicator(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "RECORDING" in panel
+        assert "●" in panel
+
+    def test_panel_contains_browser_section(self):
+        renderer = Renderer()
+        view = _make_view_with_events()
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "Browser" in panel
+        assert "localhost:3000" in panel
+
+    def test_panel_contains_ide_section(self):
+        renderer = Renderer()
+        view = _make_view_with_events()
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "IDE" in panel
+        assert "myapp" in panel
+
+    def test_panel_contains_terminal_section(self):
+        renderer = Renderer()
+        view = _make_view_with_events()
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "Terminal" in panel
+
+    def test_panel_contains_vpn_connected(self):
+        renderer = Renderer()
+        view = _make_view_with_events()
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "tailscale" in panel
+
+    def test_panel_shows_not_captured_when_empty(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "not captured yet" in panel
+
+    def test_panel_shows_vpn_not_connected(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "not connected" in panel
+
+    def test_footer_hint_present(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "Ctrl+C" in panel
+
+    def test_box_drawing_characters(self):
+        renderer = Renderer()
+        view = RecordingView("test")
+        lines = renderer._build(view)
+        panel = "\n".join(lines)
+        assert "╭" in panel
+        assert "╰" in panel
+        assert "│" in panel
+
+    def test_row_width_consistent(self):
+        """All border rows should have the same visual width."""
+        import re
+        renderer = Renderer()
+        view = _make_view_with_events()
+        lines = renderer._build(view)
+
+        ansi_re = re.compile(r"\033\[[0-9;]*m")
+
+        # Only check lines that start with a box-drawing char
+        border_lines = [
+            ansi_re.sub("", l) for l in lines
+            if ansi_re.sub("", l).startswith(("╭", "╰", "│", "├"))
+        ]
+        if border_lines:
+            widths = [len(l) for l in border_lines]
+            assert len(set(widths)) == 1, f"Inconsistent widths: {set(widths)}"
+
+    def test_renderer_last_line_count_updated(self):
+        """After _build, last_lines should be set on the next render (mocked TTY)."""
+        renderer = Renderer()
+        view = RecordingView("test")
+        assert renderer._last_lines == 0
+        # Verify _build returns a non-empty list
+        lines = renderer._build(view)
+        assert len(lines) > 0
+
+
+# ---------------------------------------------------------------------------
+# Renderer — clear resets state
+# ---------------------------------------------------------------------------
+
+class TestRendererClear:
+    def test_clear_resets_last_lines(self):
+        renderer = Renderer()
+        renderer._last_lines = 5
+        # is_tty() returns False in pytest, so clear() is a no-op, but
+        # we can verify it doesn't raise and state is unchanged (no-op path)
+        renderer.clear()
+        # _last_lines stays 5 because clear is a no-op when not a TTY
+        assert renderer._last_lines == 5

--- a/tests/tui/test_summary_view.py
+++ b/tests/tui/test_summary_view.py
@@ -1,0 +1,122 @@
+"""Tests for spaceload.tui.summary_view."""
+
+from __future__ import annotations
+
+import io
+import sys
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from spaceload.tui.event_poller import RecordingEvent
+from spaceload.tui.recording_view import RecordingView
+from spaceload.tui.summary_view import show_summary
+
+
+def _ts() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _populated_view() -> RecordingView:
+    view = RecordingView("my-project")
+    view.update_events([
+        RecordingEvent("browser", "tab_opened", "https://a.com", _ts(),
+                       raw={"browser": "Arc", "url": "https://a.com"}),
+        RecordingEvent("browser", "tab_opened", "https://b.com", _ts(),
+                       raw={"browser": "Arc", "url": "https://b.com"}),
+        RecordingEvent("browser", "tab_opened", "https://c.com", _ts(),
+                       raw={"browser": "Arc", "url": "https://c.com"}),
+        RecordingEvent("ide", "project_captured", "/Users/tom/payments", _ts(),
+                       raw={"client": "VS Code", "path": "/Users/tom/payments"}),
+        RecordingEvent("terminal", "session_opened", "/Users/tom/payments", _ts(),
+                       raw={"app": "iTerm2", "directory": "/Users/tom/payments"}),
+        RecordingEvent("terminal", "session_opened", "/Users/tom/payments/frontend", _ts(),
+                       raw={"app": "iTerm2", "directory": "/Users/tom/payments/frontend"}),
+        RecordingEvent("terminal", "session_opened", "/Users/tom/payments/scripts", _ts(),
+                       raw={"app": "iTerm2", "directory": "/Users/tom/payments/scripts"}),
+        RecordingEvent("vpn", "connected", "tailscale (work)", _ts(), raw={}),
+    ])
+    return view
+
+
+class TestShowSummary:
+    def _capture(self, view: RecordingView, count: int = 10) -> str:
+        buf = io.StringIO()
+        with patch("sys.stdout", new=buf):
+            show_summary(view.workspace_name, view, count)
+        return buf.getvalue()
+
+    def test_includes_workspace_name(self):
+        view = RecordingView("my-project")
+        output = self._capture(view)
+        assert "my-project" in output
+
+    def test_includes_duration(self):
+        view = RecordingView("test")
+        output = self._capture(view)
+        assert "Duration:" in output
+        assert "00:" in output
+
+    def test_includes_browser_count(self):
+        view = _populated_view()
+        output = self._capture(view)
+        assert "3" in output  # 3 tabs
+        assert "Arc" in output
+
+    def test_includes_ide_info(self):
+        view = _populated_view()
+        output = self._capture(view)
+        assert "VS Code" in output
+
+    def test_includes_terminal_count(self):
+        view = _populated_view()
+        output = self._capture(view)
+        assert "3" in output  # 3 sessions
+        assert "iTerm2" in output
+
+    def test_includes_vpn_label(self):
+        view = _populated_view()
+        output = self._capture(view)
+        assert "tailscale" in output
+
+    def test_includes_action_count(self):
+        view = RecordingView("p")
+        output = self._capture(view, count=42)
+        assert "42" in output
+
+    def test_includes_run_command(self):
+        view = RecordingView("my-project")
+        output = self._capture(view)
+        assert "spaceload run my-project" in output
+
+    def test_empty_view_shows_none(self):
+        view = RecordingView("empty")
+        output = self._capture(view)
+        assert "none" in output.lower()
+
+    def test_vpn_not_connected_shown(self):
+        view = RecordingView("test")
+        output = self._capture(view)
+        assert "not connected" in output
+
+    def test_single_browser_tab_singular(self):
+        view = RecordingView("p")
+        view.update_events([
+            RecordingEvent("browser", "tab_opened", "https://x.com", _ts(),
+                           raw={"browser": "Safari", "url": "https://x.com"}),
+        ])
+        output = self._capture(view)
+        # Singular "tab" not "tabs"
+        assert "Browser tab:" in output or "1 (Safari)" in output
+
+    def test_plural_sessions(self):
+        view = RecordingView("p")
+        for d in ["/a", "/b"]:
+            view.update_events([
+                RecordingEvent("terminal", "session_opened", d, _ts(),
+                               raw={"app": "Warp", "directory": d}),
+            ])
+        output = self._capture(view)
+        assert "2" in output
+        assert "Warp" in output


### PR DESCRIPTION
## Summary

Implements [issue #6](https://github.com/tomjosetj31/spaceload/issues/6) — a live, beautiful TUI recording experience that shows exactly what is being captured in real time.

- **Live panel** renders on every poll cycle (500 ms) using raw ANSI escape codes — no new dependencies added
- **Box-drawing borders**, `●` recording indicator, color-coded sections (green = captured, dim = not yet)
- **Elapsed timer** ticks up live in the top-right corner of the panel
- **Sections** for Browser, IDE, Terminal, and VPN update instantly as new events arrive
- **Final summary** is printed after Ctrl+C or `spaceload stop`
- **`--no-tui` flag** preserves the original one-line output exactly (for CI / scripting)
- **Graceful degradation**: if stdout is not a TTY (pipe, CI), falls back to plain text automatically

## Architecture

| File | Role |
|------|------|
| `spaceload/tui/event_poller.py` | Polls daemon socket for new events at 500 ms; tracks offset |
| `spaceload/tui/recording_view.py` | Pure state container; accumulates events by category |
| `spaceload/tui/renderer.py` | ANSI renderer; overwrites previous frame in place |
| `spaceload/tui/summary_view.py` | Prints plain-text final summary after stop |
| `spaceload/daemon/server.py` | +12 lines: new `events` socket command (returns actions since offset N) |
| `spaceload/cli/main.py` | `record` command now runs TUI in foreground; `--no-tui` skips it |

## What it looks like

```
╭─ spaceload recording ─────────────────────────────────────────────╮
│  Workspace: my-project                               00:04:32     │
│  Status: ● RECORDING                                              │
├───────────────────────────────────────────────────────────────────┤
│  Browser           Arc                                            │
│  ├─ http://localhost:3000                              just now   │
│  ├─ https://stripe.com/docs/api                         0:32 ago  │
│  └─ https://linear.app/team/abc                         1:14 ago  │
│                                                                   │
│  IDE               VS Code                                        │
│  └─ /Users/tom/code/payments-service                   captured   │
│                                                                   │
│  Terminal          iTerm2 (3 sessions)                            │
│  ├─ ~/code/payments-service                                       │
│  ├─ ~/code/payments-service/frontend                              │
│  └─ ~/code/payments-service/scripts                               │
│                                                                   │
│  VPN               not connected                                  │
╰───────────────────────────────────────────────────────────────────╯
  Press Ctrl+C or run `spaceload stop` to finish recording
```

After Ctrl+C:
```
Recording complete: my-project
Duration: 00:04:32

Captured:
  Browser tabs:  3 (Arc)
  IDE:           VS Code — 1 project
  Terminals:     3 sessions (iTerm2)
  VPN:           not connected

Saved 7 actions. Run it with: spaceload run my-project
```

## Test plan

- [x] 73 new unit tests passing (`tests/tui/`)
- [x] `EventPoller` converts all action types to `RecordingEvent`
- [x] `EventPoller` handles daemon not running gracefully (returns `[]`)
- [x] `EventPoller` tracks offset correctly across multiple polls
- [x] `RecordingView` categorises all event types correctly
- [x] `RecordingView` handles VPN connect/disconnect transitions
- [x] `Renderer` is a no-op when stdout is not a TTY
- [x] `Renderer` panel widths are consistent (box-drawing alignment)
- [x] `SummaryView` shows correct counts and plural forms
- [x] `SummaryView` includes workspace name and run command

🤖 Generated with [Claude Code](https://claude.com/claude-code)