### PR TITLE
feat: add docker, kubectl, aws, obsidian, tableplus, and pycharm adapters

### DIFF
--- a/spaceload/adapters/ide/pycharm.py
+++ b/spaceload/adapters/ide/pycharm.py
@@ -1,0 +1,125 @@
+"""PyCharm IDE adapter for spaceload."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from spaceload.adapters.ide.base import IDEAdapter
+
+logger = logging.getLogger(__name__)
+
+# Known PyCharm application bundle names (CE and Professional)
+_APP_NAMES = ["PyCharm", "PyCharm CE"]
+
+# AppleScript to get window titles from any running PyCharm variant
+_GET_WINDOW_TITLES_SCRIPT_TMPL = """\
+tell application "System Events"
+    if exists (process "{app}") then
+        tell process "{app}"
+            set windowNames to {{}}
+            repeat with w in windows
+                set end of windowNames to name of w
+            end repeat
+            set AppleScript's text item delimiters to "\\n"
+            return windowNames as text
+        end tell
+    end if
+    return ""
+end tell
+"""
+
+
+def _pycharm_process_names() -> list[str]:
+    """Return the OS-level process names of running PyCharm variants."""
+    running = []
+    for app in _APP_NAMES:
+        result = subprocess.run(
+            ["pgrep", "-x", app],
+            capture_output=True,
+        )
+        if result.returncode == 0:
+            running.append(app)
+    return running
+
+
+def _get_open_projects_from_applescript(app_name: str) -> list[str]:
+    """Read open project paths from PyCharm window titles via AppleScript.
+
+    PyCharm window titles look like:
+    - "project-name – main.py"
+    - "project-name [~/projects/project-name]"
+    - "~/projects/project-name – main.py"
+    """
+    try:
+        script = _GET_WINDOW_TITLES_SCRIPT_TMPL.format(app=app_name)
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+        paths = []
+        for title in result.stdout.strip().split("\n"):
+            if not title:
+                continue
+            # Extract bracketed path: "name [/full/path]"
+            if "[" in title and "]" in title:
+                bracket_start = title.rfind("[")
+                bracket_end = title.rfind("]")
+                candidate = title[bracket_start + 1 : bracket_end].strip()
+                expanded = str(Path(candidate).expanduser())
+                if Path(expanded).exists():
+                    paths.append(expanded)
+                    continue
+            # Strip " – ..." or " — ..." filename suffix and try as a path
+            for sep in (" – ", " — ", " - "):
+                if sep in title:
+                    candidate = title.split(sep)[0].strip()
+                    break
+            else:
+                candidate = title.strip()
+            expanded = str(Path(candidate).expanduser())
+            if Path(expanded).is_dir():
+                paths.append(expanded)
+        return paths
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.debug("PyCharmAdapter: AppleScript error: %s", exc)
+        return []
+
+
+class PyCharmAdapter(IDEAdapter):
+    """Adapter for PyCharm (Community Edition and Professional) on macOS."""
+
+    @property
+    def name(self) -> str:
+        return "pycharm"
+
+    def is_available(self) -> bool:
+        """Return True if any PyCharm variant is running."""
+        return bool(_pycharm_process_names())
+
+    def get_open_projects(self) -> list[str]:
+        """Return the filesystem paths of all currently open PyCharm projects."""
+        paths: set[str] = set()
+        for app_name in _pycharm_process_names():
+            paths.update(_get_open_projects_from_applescript(app_name))
+        result = list(paths)
+        logger.info("PyCharmAdapter: open projects: %s", result)
+        return result
+
+    def open_project(self, path: str) -> bool:
+        """Open a project in PyCharm using 'open -a PyCharm /path'."""
+        # Try Professional first, then CE
+        for app in _APP_NAMES:
+            result = subprocess.run(
+                ["open", "-a", app, path],
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                return True
+        logger.warning("PyCharmAdapter.open_project(): could not open %r", path)
+        return False

--- a/spaceload/adapters/ide/registry.py
+++ b/spaceload/adapters/ide/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from spaceload.adapters.ide.base import IDEAdapter
 from spaceload.adapters.ide.cursor import CursorAdapter
+from spaceload.adapters.ide.pycharm import PyCharmAdapter
 from spaceload.adapters.ide.vscode import VSCodeAdapter
 from spaceload.adapters.ide.zed import ZedAdapter
 
@@ -16,6 +17,7 @@ class IDEAdapterRegistry:
             VSCodeAdapter(),
             CursorAdapter(),
             ZedAdapter(),
+            PyCharmAdapter(),
         ]
 
     def available_adapters(self) -> list[IDEAdapter]:

--- a/spaceload/adapters/tools/__init__.py
+++ b/spaceload/adapters/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Developer tool adapters for spaceload (docker, kubectl, aws, obsidian, tableplus)."""

--- a/spaceload/adapters/tools/aws.py
+++ b/spaceload/adapters/tools/aws.py
@@ -1,0 +1,78 @@
+"""AWS CLI tool adapter for spaceload."""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from spaceload.adapters.tools.base import ToolAdapter
+
+logger = logging.getLogger(__name__)
+
+_AWS_CONFIG_PATH = Path.home() / ".aws" / "config"
+
+
+class AWSAdapter(ToolAdapter):
+    """Adapter for the AWS CLI: records the active profile and region.
+
+    On replay, prints the export commands to activate the recorded profile,
+    since environment variables cannot be set across process boundaries.
+    """
+
+    name = "aws"
+    action_type = "aws_profile"
+
+    def is_available(self) -> bool:
+        """Return True if the aws CLI or ~/.aws/config is present."""
+        return shutil.which("aws") is not None or _AWS_CONFIG_PATH.exists()
+
+    def detect(self) -> dict | None:
+        """Return the active AWS profile and region, or None if unavailable."""
+        if not self.is_available():
+            return None
+
+        profile = (
+            os.environ.get("AWS_PROFILE")
+            or os.environ.get("AWS_DEFAULT_PROFILE")
+        )
+        region = (
+            os.environ.get("AWS_DEFAULT_REGION")
+            or os.environ.get("AWS_REGION")
+        )
+
+        # Fall back to reading the [default] section from ~/.aws/config
+        if not profile and _AWS_CONFIG_PATH.exists():
+            try:
+                parser = configparser.ConfigParser()
+                parser.read(_AWS_CONFIG_PATH)
+                # AWS config sections look like "default" or "profile myprofile"
+                if "default" in parser:
+                    profile = "default"
+                    if not region:
+                        region = parser["default"].get("region")
+            except Exception as exc:
+                logger.debug("AWSAdapter.detect(): failed to read config: %s", exc)
+
+        if not profile:
+            return None
+
+        return {
+            "profile": profile,
+            "region": region or None,
+        }
+
+    def apply(self, state: dict) -> bool:
+        """Print the export commands needed to activate the recorded profile."""
+        profile = state.get("profile", "")
+        region = state.get("region")
+        if not profile:
+            return False
+        # Replay is informational — env vars cannot be set in the parent shell
+        print(f"         [ok] Recorded — to activate run:")
+        print(f"              export AWS_PROFILE={profile}")
+        if region:
+            print(f"              export AWS_DEFAULT_REGION={region}")
+        return True

--- a/spaceload/adapters/tools/base.py
+++ b/spaceload/adapters/tools/base.py
@@ -1,0 +1,30 @@
+"""Tool adapter base class for spaceload."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class ToolAdapter(ABC):
+    """Abstract base class for developer tool adapters.
+
+    Each adapter captures state from a CLI tool or app and can restore it
+    during replay.  ``detect()`` returns a payload dict (merged with ``type``
+    and ``timestamp`` by the poller) or ``None`` when nothing can be read.
+    ``apply()`` is called by the replayer with the full action dict.
+    """
+
+    name: str = ""
+    action_type: str = ""  # e.g. "docker_containers", "kubectl_context"
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Return True if the tool binary or config is present on this system."""
+
+    @abstractmethod
+    def detect(self) -> dict | None:
+        """Return a state payload dict, or None if unavailable / no state."""
+
+    @abstractmethod
+    def apply(self, state: dict) -> bool:
+        """Restore recorded state. Returns True on success."""

--- a/spaceload/adapters/tools/docker.py
+++ b/spaceload/adapters/tools/docker.py
@@ -1,0 +1,71 @@
+"""Docker tool adapter for spaceload."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+from spaceload.adapters.tools.base import ToolAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class DockerAdapter(ToolAdapter):
+    """Adapter for Docker: records running containers and starts them on replay."""
+
+    name = "docker"
+    action_type = "docker_containers"
+
+    def is_available(self) -> bool:
+        """Return True if the docker binary is on PATH."""
+        return shutil.which("docker") is not None
+
+    def detect(self) -> dict | None:
+        """Return the names of currently running containers, or None if unavailable."""
+        if not self.is_available():
+            return None
+        try:
+            result = subprocess.run(
+                ["docker", "ps", "--format", "{{.Names}}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.debug("DockerAdapter.detect(): docker ps failed (returncode=%d)", result.returncode)
+                return None
+            containers = [c.strip() for c in result.stdout.strip().splitlines() if c.strip()]
+            return {"containers": containers}
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning("DockerAdapter.detect() failed: %s", exc)
+            return None
+
+    def apply(self, state: dict) -> bool:
+        """Start each recorded container with 'docker start <name>'.
+
+        Returns True if all starts succeeded, False if any failed.
+        """
+        containers = state.get("containers", [])
+        if not containers:
+            return True
+        all_ok = True
+        for name in containers:
+            try:
+                result = subprocess.run(
+                    ["docker", "start", name],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode != 0:
+                    logger.warning(
+                        "DockerAdapter.apply(): failed to start %r: %s",
+                        name,
+                        result.stderr.strip(),
+                    )
+                    all_ok = False
+            except (subprocess.SubprocessError, OSError) as exc:
+                logger.warning("DockerAdapter.apply(): error starting %r: %s", name, exc)
+                all_ok = False
+        return all_ok

--- a/spaceload/adapters/tools/kubectl.py
+++ b/spaceload/adapters/tools/kubectl.py
@@ -1,0 +1,71 @@
+"""kubectl tool adapter for spaceload."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+
+from spaceload.adapters.tools.base import ToolAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class KubectlAdapter(ToolAdapter):
+    """Adapter for kubectl: records the active context and restores it on replay."""
+
+    name = "kubectl"
+    action_type = "kubectl_context"
+
+    def is_available(self) -> bool:
+        """Return True if kubectl is on PATH."""
+        return shutil.which("kubectl") is not None
+
+    def detect(self) -> dict | None:
+        """Return the current kubectl context, or None if unavailable."""
+        if not self.is_available():
+            return None
+        try:
+            result = subprocess.run(
+                ["kubectl", "config", "current-context"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.debug(
+                    "KubectlAdapter.detect(): current-context failed (returncode=%d)",
+                    result.returncode,
+                )
+                return None
+            context = result.stdout.strip()
+            if not context:
+                return None
+            return {"context": context}
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning("KubectlAdapter.detect() failed: %s", exc)
+            return None
+
+    def apply(self, state: dict) -> bool:
+        """Switch to the recorded kubectl context."""
+        context = state.get("context", "")
+        if not context:
+            return False
+        try:
+            result = subprocess.run(
+                ["kubectl", "config", "use-context", context],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "KubectlAdapter.apply(): use-context %r failed: %s",
+                    context,
+                    result.stderr.strip(),
+                )
+                return False
+            return True
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning("KubectlAdapter.apply() failed: %s", exc)
+            return False

--- a/spaceload/adapters/tools/obsidian.py
+++ b/spaceload/adapters/tools/obsidian.py
@@ -1,0 +1,94 @@
+"""Obsidian adapter for spaceload."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+from spaceload.adapters.tools.base import ToolAdapter
+
+logger = logging.getLogger(__name__)
+
+# Primary location on macOS
+_CONFIG_PATH_MAC = Path.home() / "Library" / "Application Support" / "obsidian" / "obsidian.json"
+# XDG fallback (Linux / custom setups)
+_CONFIG_PATH_XDG = Path.home() / ".config" / "obsidian" / "obsidian.json"
+
+
+def _config_path() -> Path | None:
+    for p in (_CONFIG_PATH_MAC, _CONFIG_PATH_XDG):
+        if p.exists():
+            return p
+    return None
+
+
+class ObsidianAdapter(ToolAdapter):
+    """Adapter for Obsidian: records the open vault path and reopens it on replay."""
+
+    name = "obsidian"
+    action_type = "obsidian_vault_open"
+
+    def is_available(self) -> bool:
+        """Return True if the Obsidian config file is present."""
+        return _config_path() is not None
+
+    def detect(self) -> dict | None:
+        """Return the currently open vault path from obsidian.json, or None.
+
+        Prefers the vault marked ``open: true``; falls back to the vault with
+        the highest ``ts`` (most recently accessed).
+        """
+        cfg = _config_path()
+        if cfg is None:
+            return None
+        try:
+            data = json.loads(cfg.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("ObsidianAdapter.detect(): failed to read config: %s", exc)
+            return None
+
+        vaults = data.get("vaults", {})
+        if not vaults:
+            return None
+
+        # Prefer the currently open vault
+        open_vault = next(
+            (v for v in vaults.values() if v.get("open")),
+            None,
+        )
+        if open_vault:
+            vault_path = open_vault.get("path", "")
+            if vault_path:
+                return {"vault_path": vault_path}
+
+        # Fall back to most recently accessed vault
+        most_recent = max(vaults.values(), key=lambda v: v.get("ts", 0), default=None)
+        if most_recent:
+            vault_path = most_recent.get("path", "")
+            if vault_path:
+                return {"vault_path": vault_path}
+
+        return None
+
+    def apply(self, state: dict) -> bool:
+        """Open the recorded vault in Obsidian."""
+        vault_path = state.get("vault_path", "")
+        if not vault_path:
+            return False
+        try:
+            result = subprocess.run(
+                ["open", "-a", "Obsidian", vault_path],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "ObsidianAdapter.apply(): failed to open vault %r", vault_path
+                )
+                return False
+            return True
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning("ObsidianAdapter.apply() failed: %s", exc)
+            return False

--- a/spaceload/adapters/tools/registry.py
+++ b/spaceload/adapters/tools/registry.py
@@ -1,0 +1,38 @@
+"""Tool adapter registry for spaceload."""
+
+from __future__ import annotations
+
+import logging
+
+from spaceload.adapters.tools.base import ToolAdapter
+from spaceload.adapters.tools.docker import DockerAdapter
+from spaceload.adapters.tools.kubectl import KubectlAdapter
+from spaceload.adapters.tools.aws import AWSAdapter
+from spaceload.adapters.tools.obsidian import ObsidianAdapter
+from spaceload.adapters.tools.tableplus import TablePlusAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class ToolAdapterRegistry:
+    """Registry of all known developer tool adapters."""
+
+    def __init__(self) -> None:
+        self._adapters: list[ToolAdapter] = [
+            DockerAdapter(),
+            KubectlAdapter(),
+            AWSAdapter(),
+            ObsidianAdapter(),
+            TablePlusAdapter(),
+        ]
+
+    def available_adapters(self) -> list[ToolAdapter]:
+        """Return adapters whose tool is installed/accessible on this system."""
+        return [a for a in self._adapters if a.is_available()]
+
+    def get_adapter(self, name: str) -> ToolAdapter | None:
+        """Return adapter by name (e.g. 'docker'), or None if not found."""
+        for adapter in self._adapters:
+            if adapter.name == name:
+                return adapter
+        return None

--- a/spaceload/adapters/tools/tableplus.py
+++ b/spaceload/adapters/tools/tableplus.py
@@ -1,0 +1,137 @@
+"""TablePlus adapter for spaceload."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import subprocess
+from pathlib import Path
+from urllib.parse import quote
+
+from spaceload.adapters.tools.base import ToolAdapter
+
+logger = logging.getLogger(__name__)
+
+_APP_SUPPORT = Path.home() / "Library" / "Application Support" / "com.tinyapp.TablePlus" / "Data"
+_CONNECTIONS_DB = _APP_SUPPORT / "Connections"
+
+# AppleScript to read the front TablePlus window title (shows active connection)
+_GET_WINDOW_TITLE_SCRIPT = """\
+tell application "System Events"
+    if exists (process "TablePlus") then
+        tell process "TablePlus"
+            if (count of windows) > 0 then
+                return name of front window
+            end if
+        end tell
+    end if
+    return ""
+end tell
+"""
+
+
+def _get_active_connection_from_applescript() -> str | None:
+    """Return the active connection name from the TablePlus window title."""
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", _GET_WINDOW_TITLE_SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        title = result.stdout.strip()
+        if not title:
+            return None
+        # TablePlus window titles are typically "ConnectionName (database)" or just "ConnectionName"
+        # Strip the "(database)" suffix if present
+        if " (" in title:
+            title = title[: title.rfind(" (")]
+        return title or None
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.debug("TablePlusAdapter: AppleScript error: %s", exc)
+        return None
+
+
+def _get_most_recent_connection_from_db() -> str | None:
+    """Return the most recently used connection name from the TablePlus SQLite DB."""
+    if not _CONNECTIONS_DB.exists():
+        return None
+    try:
+        with sqlite3.connect(str(_CONNECTIONS_DB)) as conn:
+            cur = conn.execute("SELECT data FROM connections ORDER BY rowid DESC LIMIT 20")
+            rows = cur.fetchall()
+        for (data_str,) in rows:
+            try:
+                info = json.loads(data_str) if isinstance(data_str, str) else data_str
+                name = info.get("ConnectionName") or info.get("Name") or info.get("name")
+                if name:
+                    return str(name)
+            except (json.JSONDecodeError, TypeError):
+                continue
+    except (sqlite3.Error, OSError) as exc:
+        logger.debug("TablePlusAdapter: DB read error: %s", exc)
+    return None
+
+
+class TablePlusAdapter(ToolAdapter):
+    """Adapter for TablePlus: records the active DB connection and reopens it."""
+
+    name = "tableplus"
+    action_type = "tableplus_connection_open"
+
+    def is_available(self) -> bool:
+        """Return True if the TablePlus data directory exists."""
+        return _APP_SUPPORT.exists()
+
+    def detect(self) -> dict | None:
+        """Return the active connection name, or None if unavailable.
+
+        Prefers the live window title (AppleScript); falls back to the
+        most recently listed entry in the connections database.
+        """
+        if not self.is_available():
+            return None
+
+        connection_name = _get_active_connection_from_applescript()
+        if not connection_name:
+            connection_name = _get_most_recent_connection_from_db()
+        if not connection_name:
+            return None
+
+        return {"connection_name": connection_name}
+
+    def apply(self, state: dict) -> bool:
+        """Open TablePlus, attempting to navigate to the recorded connection.
+
+        Tries the ``tableplus://open?name=<name>`` URL scheme first;
+        falls back to launching the app with no specific connection.
+        """
+        connection_name = state.get("connection_name", "")
+        if connection_name:
+            try:
+                encoded = quote(connection_name, safe="")
+                result = subprocess.run(
+                    ["open", f"tableplus://open?name={encoded}"],
+                    capture_output=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    return True
+                logger.debug(
+                    "TablePlusAdapter.apply(): URL scheme failed, falling back to open -a"
+                )
+            except (subprocess.SubprocessError, OSError) as exc:
+                logger.debug("TablePlusAdapter.apply(): URL scheme error: %s", exc)
+
+        # Fallback: just open the app
+        try:
+            result = subprocess.run(
+                ["open", "-a", "TablePlus"],
+                capture_output=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.warning("TablePlusAdapter.apply() failed: %s", exc)
+            return False

--- a/spaceload/adapters/wm/app_names.py
+++ b/spaceload/adapters/wm/app_names.py
@@ -15,6 +15,7 @@ IDE_APP_NAMES: dict[str, str] = {
     "vscode": "Code",
     "cursor": "Cursor",
     "zed": "Zed",
+    "pycharm": "PyCharm",
 }
 
 # Maps ctx terminal adapter name → app name as reported by the WM

--- a/spaceload/daemon/server.py
+++ b/spaceload/daemon/server.py
@@ -34,6 +34,7 @@ from spaceload.adapters.vpn.registry import VPNAdapterRegistry
 from spaceload.adapters.browser.registry import BrowserAdapterRegistry
 from spaceload.adapters.ide.registry import IDEAdapterRegistry
 from spaceload.adapters.terminal.registry import TerminalAdapterRegistry
+from spaceload.adapters.tools.registry import ToolAdapterRegistry
 from spaceload.adapters.wm.registry import WorkspaceManagerRegistry
 from spaceload.adapters.wm.app_names import BROWSER_APP_NAMES, IDE_APP_NAMES, TERMINAL_APP_NAMES
 
@@ -880,6 +881,88 @@ class TerminalPoller:
         self._known_dirs[adapter.name] = current_dirs
 
 
+class DevToolsPoller:
+    """Background thread that polls developer tool state (docker, kubectl, aws, etc.).
+
+    On the first poll each available adapter captures its baseline state and
+    emits an action immediately — tool context is always relevant to replay.
+    On subsequent polls an action is emitted only when the state changes.
+    """
+
+    def __init__(
+        self,
+        actions: list[dict],
+        poll_interval: float = 5.0,
+    ) -> None:
+        self._actions = actions
+        self._poll_interval = poll_interval
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        # Maps adapter name → last emitted state dict (or None = not yet seen)
+        self._last_state: dict[str, dict | None] = {}
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="devtools-poller"
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._poll_interval + 1)
+
+    def _run(self) -> None:
+        try:
+            registry = ToolAdapterRegistry()
+        except Exception as exc:
+            logger.warning("DevToolsPoller: could not initialise registry: %s", exc)
+            return
+
+        while not self._stop_event.is_set():
+            try:
+                self._poll(registry)
+            except Exception as exc:
+                logger.warning("DevToolsPoller: poll error: %s", exc)
+            self._stop_event.wait(timeout=self._poll_interval)
+
+    def _poll(self, registry) -> None:
+        for adapter in registry.available_adapters():
+            try:
+                state = adapter.detect()
+            except Exception as exc:
+                logger.warning("DevToolsPoller: error detecting %s: %s", adapter.name, exc)
+                continue
+
+            if state is None:
+                continue
+
+            last = self._last_state.get(adapter.name)
+            if self._states_differ(last, state):
+                action = {
+                    "type": adapter.action_type,
+                    "timestamp": _now_iso(),
+                    **state,
+                }
+                self._actions.append(action)
+                logger.info(
+                    "DevToolsPoller: RECORDED %s %s", adapter.action_type, state
+                )
+                self._last_state[adapter.name] = state
+
+    @staticmethod
+    def _states_differ(old: dict | None, new: dict | None) -> bool:
+        """Return True when two state dicts represent different tool state."""
+        if old is None:
+            return True  # first observation — always emit
+        if old is new:
+            return False
+        # Normalise list values to sorted tuples for stable comparison
+        def _norm(d: dict) -> dict:
+            return {k: (tuple(sorted(v)) if isinstance(v, list) else v) for k, v in d.items()}
+        return _norm(old) != _norm(new)
+
+
 def _get_running_foreground_apps() -> set[str]:
     """Return names of all visible (foreground) apps.
 
@@ -1126,6 +1209,7 @@ class RecorderDaemon:
         self._browser_poller: BrowserPoller | None = None
         self._ide_poller: IDEPoller | None = None
         self._terminal_poller: TerminalPoller | None = None
+        self._devtools_poller: DevToolsPoller | None = None
         self._window_poller: WindowSnapshotPoller | None = None
 
     # ------------------------------------------------------------------
@@ -1170,6 +1254,9 @@ class RecorderDaemon:
 
         self._terminal_poller = TerminalPoller(self._actions, include_open=self.include_open)
         self._terminal_poller.start()
+
+        self._devtools_poller = DevToolsPoller(self._actions)
+        self._devtools_poller.start()
 
         self._window_poller = WindowSnapshotPoller(self._actions, include_open=self.include_open)
         self._window_poller.start()
@@ -1289,6 +1376,8 @@ class RecorderDaemon:
             self._ide_poller.stop()
         if self._terminal_poller is not None:
             self._terminal_poller.stop()
+        if self._devtools_poller is not None:
+            self._devtools_poller.stop()
         if self._window_poller is not None:
             self._window_poller.stop()
 

--- a/spaceload/replayer/replayer.py
+++ b/spaceload/replayer/replayer.py
@@ -45,6 +45,26 @@ def _setup_replay_logging() -> None:
 
 _SENTINEL = object()  # marks "not yet initialised" for the aerospace field
 
+
+def _tool_action_summary(action: dict) -> str:
+    """Return a short human-readable summary of a tool state action."""
+    t = action.get("type", "")
+    if t == "docker_containers":
+        containers = action.get("containers", [])
+        return f"{len(containers)} container(s): {', '.join(containers[:3])}" + (
+            " …" if len(containers) > 3 else ""
+        )
+    if t == "kubectl_context":
+        return f"context={action.get('context', '')!r}"
+    if t == "aws_profile":
+        region = action.get("region") or ""
+        return f"profile={action.get('profile', '')!r}" + (f" region={region!r}" if region else "")
+    if t == "obsidian_vault_open":
+        return f"vault={action.get('vault_path', '')!r}"
+    if t == "tableplus_connection_open":
+        return f"connection={action.get('connection_name', '')!r}"
+    return str(action)
+
 # How long to wait (seconds) after opening an app before trying to move its window
 _AEROSPACE_SETTLE = 1.5
 
@@ -72,6 +92,7 @@ class Replayer:
         self._browser_registry = None  # Browser — lazy-loaded
         self._ide_registry = None      # IDE — lazy-loaded
         self._terminal_registry = None  # Terminal — lazy-loaded
+        self._tools_registry = None    # DevTools — lazy-loaded
         self._aerospace: object | None = _SENTINEL  # AeroSpace — lazy-loaded
         self._opened_terminal_sessions: set[str] = set()  # Track opened sessions
 
@@ -102,6 +123,13 @@ class Replayer:
             from spaceload.adapters.terminal.registry import TerminalAdapterRegistry
             self._terminal_registry = TerminalAdapterRegistry()
         return self._terminal_registry
+
+    def _get_tools_registry(self):
+        """Return a ToolAdapterRegistry, initialising it on first call."""
+        if self._tools_registry is None:
+            from spaceload.adapters.tools.registry import ToolAdapterRegistry
+            self._tools_registry = ToolAdapterRegistry()
+        return self._tools_registry
 
     def _get_aerospace(self):
         """Return the active workspace manager adapter, or None. Cached after first call."""
@@ -199,6 +227,14 @@ class Replayer:
                     self._handle_terminal_command(i, action)
             elif action_type == "app_open":
                 self._handle_app_open(i, action)
+            elif action_type in (
+                "docker_containers",
+                "kubectl_context",
+                "aws_profile",
+                "obsidian_vault_open",
+                "tableplus_connection_open",
+            ):
+                self._handle_tool_state(i, action)
             else:
                 print(f"  [{i:>3}] {action_type}: {data}")
 
@@ -512,6 +548,45 @@ class Replayer:
 
         if workspace:
             self._place_in_workspace(app_name, workspace)
+
+    # ------------------------------------------------------------------
+    # Developer tool action handlers
+    # ------------------------------------------------------------------
+
+    def _handle_tool_state(self, index: int, action: dict[str, Any]) -> None:
+        """Replay a developer tool state action via the ToolAdapterRegistry."""
+        action_type = action.get("type", "")
+        registry = self._get_tools_registry()
+
+        # Map action type → adapter name
+        _TYPE_TO_ADAPTER = {
+            "docker_containers": "docker",
+            "kubectl_context": "kubectl",
+            "aws_profile": "aws",
+            "obsidian_vault_open": "obsidian",
+            "tableplus_connection_open": "tableplus",
+        }
+        adapter_name = _TYPE_TO_ADAPTER.get(action_type, "")
+
+        # Print a brief summary line
+        summary = _tool_action_summary(action)
+        print(f"  [{index:>3}] {action_type}: {summary}")
+
+        adapter = registry.get_adapter(adapter_name)
+        if adapter is None:
+            logger.warning("  Result: SKIPPED - no adapter found for %r", adapter_name)
+            print(f"         [warn] No adapter for '{adapter_name}' — skipping")
+            return
+
+        success = adapter.apply(action)
+        if success:
+            logger.info("  Result: SUCCESS - applied %s via %s", action_type, adapter_name)
+            if action_type != "aws_profile":
+                # aws_profile prints its own [ok] line inside apply()
+                print(f"         [ok] Applied {action_type}")
+        else:
+            logger.warning("  Result: FAILED - could not apply %s", action_type)
+            print(f"         [warn] Could not apply {action_type} — continuing")
 
     # ------------------------------------------------------------------
     # AeroSpace workspace placement helper


### PR DESCRIPTION
## Summary

- Adds a new `tools` adapter family (`docker`, `kubectl`, `aws`, `obsidian`, `tableplus`) with a shared `ToolAdapter` ABC, `ToolAdapterRegistry`, and a `DevToolsPoller` that captures state changes during recording
- Adds `PyCharmAdapter` (Pro + CE) to the IDE family, registered alongside VSCode, Cursor, and Zed
- Wires all new action types into the replayer (`docker_containers`, `kubectl_context`, `aws_profile`, `obsidian_vault_open`, `tableplus_connection_open`)

## What each adapter does

| Adapter | Record | Replay |
|---|---|---|
| `docker` | `docker ps` — running container names | `docker start <name>` per container |
| `kubectl` | `kubectl config current-context` | `kubectl config use-context <ctx>` |
| `aws` | `AWS_PROFILE` env / `~/.aws/config` | Prints `export AWS_PROFILE=...` (env vars can't cross process boundaries) |
| `obsidian` | Reads `obsidian.json`; prefers `open: true` vault | `open -a Obsidian <vault_path>` |
| `tableplus` | AppleScript window title → SQLite connections DB fallback | `tableplus://open?name=<name>` URL scheme, falls back to `open -a TablePlus` |
| `pycharm` | AppleScript window titles (bracketed path or dir prefix) | `open -a PyCharm <path>`, falls back to `PyCharm CE` |

## Architecture

`DevToolsPoller` runs at 5s intervals alongside the existing five pollers. On the first poll it always emits current state (tool context is always relevant to replay); subsequent polls emit only on state change. List-valued state (docker containers) is compared as a sorted tuple to avoid spurious re-emissions on reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)